### PR TITLE
Swipe handling improvements

### DIFF
--- a/dist/pm-carousel.mjs
+++ b/dist/pm-carousel.mjs
@@ -7,7 +7,9 @@ const ATTRPREV = `${ATTR}-prev`;
 const ATTRNEXT = `${ATTR}-next`;
 const ATTRPLAYSTOP = `${ATTR}-playstop`;
 const TRANSITION = "transform .5s ease-in-out";
+const TRANSITION_SWIPE = "transform .1s ease-out";
 const ACTIVECLASS = "is-active";
+const SLIDE_MIN_RATIO = 6;
 const buildActions = {
   playstop: function() {
     if (!this.nodes.playstop) return;
@@ -363,23 +365,43 @@ function onTouchStart(ev) {
     this.stop();
     this.nodes.overflow.style.transition = "none";
     this._metrics.touchstartX = Math.round(ev.touches[0].pageX);
+    this._metrics.touchstartY = Math.round(ev.touches[0].pageY);
     this._metrics.slideWidth = this.nodes.wrapper.offsetWidth;
+    this._metrics.isScrolling = false;
+    this._metrics.isSwiping = false;
   });
 }
 function onTouchMove(ev) {
   handleRequestAnimationFrame("onTouchMove", () => {
     this._metrics.moveX = this._metrics.touchstartX - Math.round(ev.touches[0].pageX);
-    this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance - this._metrics.moveX}px)`;
+    this._metrics.moveY = this._metrics.touchstartY - Math.round(ev.touches[0].pageY);
+    if (!this._metrics.isScrolling && !this._metrics.isSwiping) {
+      if (Math.abs(this._metrics.moveX) > Math.abs(this._metrics.moveY)) {
+        this._metrics.isSwiping = true;
+      } else {
+        this._metrics.isScrolling = true;
+      }
+    }
+    if (this._metrics.isSwiping) {
+      document.documentElement.style.overflow = "hidden";
+      this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance - this._metrics.moveX}px)`;
+    }
   });
 }
 function onTouchEnd() {
   handleRequestAnimationFrame("onTouchEnd", () => {
-    const goToNext = this._metrics.moveX > this._metrics.slideWidth / 3;
-    const goToPrev = this._metrics.moveX < -this._metrics.slideWidth / 3;
-    this.nodes.overflow.style.transition = TRANSITION;
+    if (!this._metrics.isSwiping) {
+      return;
+    }
+    const goToNext = this._metrics.moveX > this._metrics.slideWidth / SLIDE_MIN_RATIO;
+    const goToPrev = this._metrics.moveX < -this._metrics.slideWidth / SLIDE_MIN_RATIO;
+    document.documentElement.style.removeProperty("overflow");
     let newActive = this.activePage;
     this._metrics.moveX = 0;
+    this._metrics.isScrolling = false;
+    this._metrics.isSwiping = false;
     if (!goToNext && !goToPrev) {
+      this.nodes.overflow.style.transition = TRANSITION;
       this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance}px)`;
       return;
     }
@@ -481,6 +503,11 @@ class Plugin {
     }
     if (this.activePage > this.pagesLength - 1) {
       this.activePage = this.currentSettings.loop && !isSwipe ? 0 : this.pagesLength - 1;
+    }
+    if (isSwipe) {
+      this.nodes.overflow.style.transition = TRANSITION_SWIPE;
+    } else {
+      this.nodes.overflow.style.transition = TRANSITION;
     }
     setActive.call(this);
   }

--- a/dist/pm-carousel.umd.js
+++ b/dist/pm-carousel.umd.js
@@ -11,7 +11,9 @@
   const ATTRNEXT = `${ATTR}-next`;
   const ATTRPLAYSTOP = `${ATTR}-playstop`;
   const TRANSITION = "transform .5s ease-in-out";
+  const TRANSITION_SWIPE = "transform .1s ease-out";
   const ACTIVECLASS = "is-active";
+  const SLIDE_MIN_RATIO = 6;
   const buildActions = {
     playstop: function() {
       if (!this.nodes.playstop) return;
@@ -367,23 +369,43 @@
       this.stop();
       this.nodes.overflow.style.transition = "none";
       this._metrics.touchstartX = Math.round(ev.touches[0].pageX);
+      this._metrics.touchstartY = Math.round(ev.touches[0].pageY);
       this._metrics.slideWidth = this.nodes.wrapper.offsetWidth;
+      this._metrics.isScrolling = false;
+      this._metrics.isSwiping = false;
     });
   }
   function onTouchMove(ev) {
     handleRequestAnimationFrame("onTouchMove", () => {
       this._metrics.moveX = this._metrics.touchstartX - Math.round(ev.touches[0].pageX);
-      this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance - this._metrics.moveX}px)`;
+      this._metrics.moveY = this._metrics.touchstartY - Math.round(ev.touches[0].pageY);
+      if (!this._metrics.isScrolling && !this._metrics.isSwiping) {
+        if (Math.abs(this._metrics.moveX) > Math.abs(this._metrics.moveY)) {
+          this._metrics.isSwiping = true;
+        } else {
+          this._metrics.isScrolling = true;
+        }
+      }
+      if (this._metrics.isSwiping) {
+        document.documentElement.style.overflow = "hidden";
+        this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance - this._metrics.moveX}px)`;
+      }
     });
   }
   function onTouchEnd() {
     handleRequestAnimationFrame("onTouchEnd", () => {
-      const goToNext = this._metrics.moveX > this._metrics.slideWidth / 3;
-      const goToPrev = this._metrics.moveX < -this._metrics.slideWidth / 3;
-      this.nodes.overflow.style.transition = TRANSITION;
+      if (!this._metrics.isSwiping) {
+        return;
+      }
+      const goToNext = this._metrics.moveX > this._metrics.slideWidth / SLIDE_MIN_RATIO;
+      const goToPrev = this._metrics.moveX < -this._metrics.slideWidth / SLIDE_MIN_RATIO;
+      document.documentElement.style.removeProperty("overflow");
       let newActive = this.activePage;
       this._metrics.moveX = 0;
+      this._metrics.isScrolling = false;
+      this._metrics.isSwiping = false;
       if (!goToNext && !goToPrev) {
+        this.nodes.overflow.style.transition = TRANSITION;
         this.nodes.overflow.style.transform = `translateX(${-this._metrics.distance}px)`;
         return;
       }
@@ -485,6 +507,11 @@
       }
       if (this.activePage > this.pagesLength - 1) {
         this.activePage = this.currentSettings.loop && !isSwipe ? 0 : this.pagesLength - 1;
+      }
+      if (isSwipe) {
+        this.nodes.overflow.style.transition = TRANSITION_SWIPE;
+      } else {
+        this.nodes.overflow.style.transition = TRANSITION;
       }
       setActive.call(this);
     }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,10 @@
-import { ATTR, ACTIVECLASS, ATTRITEM } from "./src/constants"
+import {
+	ATTR,
+	ACTIVECLASS,
+	ATTRITEM,
+	TRANSITION,
+	TRANSITION_SWIPE,
+} from "./src/constants"
 
 import init from "./src/init"
 import setActive from "./src/setActive"
@@ -107,6 +113,12 @@ class Plugin {
 		if (this.activePage > this.pagesLength - 1) {
 			this.activePage =
 				this.currentSettings.loop && !isSwipe ? 0 : this.pagesLength - 1
+		}
+
+		if (isSwipe) {
+			this.nodes.overflow.style.transition = TRANSITION_SWIPE
+		} else {
+			this.nodes.overflow.style.transition = TRANSITION
 		}
 
 		setActive.call(this)

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,4 +7,6 @@ export const ATTRPREV = `${ATTR}-prev`
 export const ATTRNEXT = `${ATTR}-next`
 export const ATTRPLAYSTOP = `${ATTR}-playstop`
 export const TRANSITION = "transform .5s ease-in-out"
+export const TRANSITION_SWIPE = "transform .1s ease-out"
 export const ACTIVECLASS = "is-active"
+export const SLIDE_MIN_RATIO = 6

--- a/src/onTouch.js
+++ b/src/onTouch.js
@@ -1,4 +1,4 @@
-import { TRANSITION } from "./constants"
+import { SLIDE_MIN_RATIO, TRANSITION } from "./constants"
 
 const timeouts = {
 	onTouchStart: null,
@@ -20,7 +20,10 @@ export function onTouchStart(ev) {
 
 		this.nodes.overflow.style.transition = "none"
 		this._metrics.touchstartX = Math.round(ev.touches[0].pageX)
+		this._metrics.touchstartY = Math.round(ev.touches[0].pageY)
 		this._metrics.slideWidth = this.nodes.wrapper.offsetWidth
+		this._metrics.isScrolling = false
+		this._metrics.isSwiping = false
 	})
 }
 
@@ -28,26 +31,51 @@ export function onTouchMove(ev) {
 	handleRequestAnimationFrame("onTouchMove", () => {
 		this._metrics.moveX =
 			this._metrics.touchstartX - Math.round(ev.touches[0].pageX)
+		this._metrics.moveY =
+			this._metrics.touchstartY - Math.round(ev.touches[0].pageY)
 
-		this.nodes.overflow.style.transform = `translateX(${
-			-this._metrics.distance - this._metrics.moveX
-		}px)`
+		// Check if the gesture is primarily horizontal or vertical
+		if (!this._metrics.isScrolling && !this._metrics.isSwiping) {
+			if (Math.abs(this._metrics.moveX) > Math.abs(this._metrics.moveY)) {
+				this._metrics.isSwiping = true // Horizontal swipe
+			} else {
+				this._metrics.isScrolling = true // Vertical scroll
+			}
+		}
+
+		if (this._metrics.isSwiping) {
+			document.documentElement.style.overflow = "hidden"
+			this.nodes.overflow.style.transform = `translateX(${
+				-this._metrics.distance - this._metrics.moveX
+			}px)`
+		}
 	})
 }
 
 export function onTouchEnd() {
 	handleRequestAnimationFrame("onTouchEnd", () => {
-		const goToNext = this._metrics.moveX > this._metrics.slideWidth / 3
-		const goToPrev = this._metrics.moveX < -this._metrics.slideWidth / 3
+		if (!this._metrics.isSwiping) {
+			return
+		}
 
-		this.nodes.overflow.style.transition = TRANSITION
+		const goToNext =
+			this._metrics.moveX > this._metrics.slideWidth / SLIDE_MIN_RATIO
+		const goToPrev =
+			this._metrics.moveX < -this._metrics.slideWidth / SLIDE_MIN_RATIO
+
+		document.documentElement.style.removeProperty("overflow")
+
 		let newActive = this.activePage
 
 		// réinit moving distance
 		this._metrics.moveX = 0
 
+		this._metrics.isScrolling = false
+		this._metrics.isSwiping = false
+
 		if (!goToNext && !goToPrev) {
 			// reset to initial position
+			this.nodes.overflow.style.transition = TRANSITION
 			this.nodes.overflow.style.transform = `translateX(${-this._metrics
 				.distance}px)`
 			return


### PR DESCRIPTION
- Disable vertical page scrolling when swiping and disable swiping when scrolling vertically.
- Use a more natural CSS transition when swiping (`0.1s ease-out`).